### PR TITLE
Allow for localization of text strings

### DIFF
--- a/_dev/mediaelement-playlist-plugin.js
+++ b/_dev/mediaelement-playlist-plugin.js
@@ -2,11 +2,11 @@
 
 (function($) {
     $.extend(mejs.MepDefaults, {
-        loopText: "Repeat On/Off",
-        shuffleText: "Shuffle On/Off",
-        nextText: "Next Track",
-        prevText: "Previous Track",
-        playlistText: "Show/Hide Playlist"
+        loopText: mejs.i18n.t("Repeat On/Off"),
+        shuffleText: mejs.i18n.t("Shuffle On/Off"),
+        nextText: mejs.i18n.t("Next Track"),
+        prevText: mejs.i18n.t("Previous Track"),
+        playlistText: mejs.i18n.t("Show/Hide Playlist")
     });
     $.extend(MediaElementPlayer.prototype, {
         buildloop: function(player, controls, layers, media) {

--- a/js/mediaelement-playlist-plugin.js
+++ b/js/mediaelement-playlist-plugin.js
@@ -14,11 +14,11 @@
 
 (function ($) {
 	$.extend(mejs.MepDefaults, {
-		loopText: 'Repeat On/Off',
-		shuffleText: 'Shuffle On/Off',
-		nextText: 'Next Track',
-		prevText: 'Previous Track',
-		playlistText: 'Show/Hide Playlist'
+		loopText: mejs.i18n.t('Repeat On/Off'),
+		shuffleText: mejs.i18n.t('Shuffle On/Off'),
+		nextText: mejs.i18n.t('Next Track'),
+		prevText: mejs.i18n.t('Previous Track'),
+		playlistText: mejs.i18n.t('Show/Hide Playlist')
 	});
 
 	$.extend(MediaElementPlayer.prototype, {

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-replace": "^0.7.9"
+  },
+  "scripts": {
+    "dev": "grunt"
   }
 }


### PR DESCRIPTION
Using `mejs.i18n.t` will make sure that it's possible to localize these texts (i.e. by setting `window.mejs.i18n.locale.strings.de['Next Track'] = 'Nächster Track';`).

Unrelated, but helpful during development: Adding an npm script allows you to run `npm run dev` instead of having to install Grunt globally.